### PR TITLE
add an exposition-only utility for emplacing immovable types in containers

### DIFF
--- a/execution.bs
+++ b/execution.bs
@@ -5047,19 +5047,6 @@ enum class forward_progress_guarantee {
             structured binding declaration [dcl.struct.bind].</span>
 
     12. <pre highlight="c++">
-        template&lt;<i>callable</i> Fn>
-        struct <i>emplacer</i> { // exposition only
-          Fn fn;  // exposition only
-          operator <i>call-result-t</i>&lt;Fn> () && noexcept(<i>nothrow-callable</i>&lt;Fn>) {
-            return std::move(fn)();
-          }
-        };
-        </pre>
-
-        1. <span class="wg21note">The type `emplacer<Fn>` is used to emplace non-movable
-            types into containers like `tuple`, `optional`, and `variant`.</span>
-
-    13. <pre highlight="c++">
         template &lt;semiregular Tag, <i>movable-value</i> Data = <i>see below</i>, sender... Child>
         constexpr auto <i>make-sender</i>(Tag, Data&& data, Child&&... child);
         </pre>
@@ -6408,7 +6395,7 @@ template&lt;class Domain, class Tag, sender Sndr, class... Args>
             auto sndr2 = apply(std::move(state.fn), args);
             auto rcvr2 = <i>receiver2</i>{std::move(rcvr), std::move(state.env)};
             auto mkop2 = [&] { return connect(std::move(sndr2), std::move(rcvr2)); };
-            auto& op2 = state.ops2.emplace&lt;decltype(mkop2())>(<i>emplacer</i>{mkop2});
+            auto& op2 = state.ops2.emplace&lt;decltype(mkop2())>(<i>emplace-from</i>{mkop2});
             start(op2);
             </pre>
 

--- a/execution.bs
+++ b/execution.bs
@@ -5007,6 +5007,25 @@ enum class forward_progress_guarantee {
             [*Note:* The `transfer` algorithm is unique in that it ignores the execution domain of
             its predecessor, using only its destination scheduler to select a customization. *--end note*]
 
+    11. <pre highlight="c++">
+        template&lt;<i>callable</i> Fun>
+          requires is_nothrow_move_constructible_v&lt;Fun>
+        struct <i>emplace-construct</i> { // exposition only
+          Fun <i>fun</i>; // exposition only
+          using type = <i>call-result-t</i>&lt;Fun>;
+
+          constexpr operator type() && noexcept(<i>nothrow-callable</i>&lt;Fun>) {
+            return std::move(<i>fun</i>)();
+          }
+
+          constexpr type operator()() && noexcept(<i>nothrow-callable</i>&lt;Fun>) {
+            return std::move(<i>fun</i>)();
+          }
+        };
+        </pre>
+
+        1. <span class="wg21note"><i>`emplace-construct`</i> is used to emplace
+            non-movable types into containers like `tuple`, `optional`, and `variant`.</span>
 
     11. <pre highlight="c++">
         template&lt;class... T>

--- a/execution.bs
+++ b/execution.bs
@@ -5010,7 +5010,7 @@ enum class forward_progress_guarantee {
     11. <pre highlight="c++">
         template&lt;<i>callable</i> Fun>
           requires is_nothrow_move_constructible_v&lt;Fun>
-        struct <i>emplace-construct</i> { // exposition only
+        struct <i>emplace-from</i> { // exposition only
           Fun <i>fun</i>; // exposition only
           using type = <i>call-result-t</i>&lt;Fun>;
 
@@ -5024,7 +5024,7 @@ enum class forward_progress_guarantee {
         };
         </pre>
 
-        1. <span class="wg21note"><i>`emplace-construct`</i> is used to emplace
+        1. <span class="wg21note"><i>`emplace-from`</i> is used to emplace
             non-movable types into containers like `tuple`, `optional`, and `variant`.</span>
 
     11. <pre highlight="c++">


### PR DESCRIPTION
This will be needed by `when_all`, which keeps a `tuple` of operation states.