### PR TITLE
`when_all` should be awaitable and the result should be de-structure-able

### DIFF
--- a/execution.bs
+++ b/execution.bs
@@ -7841,7 +7841,9 @@ template&lt;class Domain, class Tag, sender Sndr, class... Args>
 
         2. Otherwise, if `value_types_of_t<Sndr, Env, Tuple, Variant>` would have the form `Variant<Tuple<>>` or `Variant<>`, then <code><i>single-sender-value-type</i>&lt;Sndr, Env></code> is an alias for type `void`.
 
-        3. Otherwise, <code><i>single-sender-value-type</i>&lt;Sndr, Env></code> is ill-formed.
+        3. Otherwise, if `value_types_of_t<Sndr, Env, Tuple, Variant>` would have the form `Variant<Tuple<Ts...>>` where `Ts` is a parameter pack, then <code><i>single-sender-value-type</i>&lt;Sndr, Env></code> is an alias for type `std::tuple<decay_t<Ts>...>`.
+
+        4. Otherwise, <code><i>single-sender-value-type</i>&lt;Sndr, Env></code> is ill-formed.
 
     2. The type <code><i>sender-awaitable</i>&lt;Sndr, Promise></code> is equivalent to the following:
 


### PR DESCRIPTION
This change makes the following well-formed:

```c++
auto [a,b,c] = co_await when_all(x, y, z);
```

Currently it is ill-formed.

fixes #182