### PR TITLE
Apply changes from P3187R1

### DIFF
--- a/execution.bs
+++ b/execution.bs
@@ -8540,7 +8540,7 @@ namespace std::execution {
     <code>sh_state-><i>dec-ref</i>()</code>.
 
 9. The exposition-only class template <i>`impls-for`</i>
-    ([exec.snd.general]) is specialized for _`split-impl-tag`_
+    ([exec.snd.general]) is specialized for <i>`split-impl-tag`</i>
     as follows:
 
         <pre highlight="c++">
@@ -8589,9 +8589,10 @@ namespace std::execution {
 
             2.  Then atomically does the following:
 
-                  - Inserts `&state` into `state.sh_state->waiting_states`, and
+                  - Reads the value `c` of `state.sh_state->completed`, and
 
-                  - Reads the value `c` of `state.sh_state->completed`.
+                  - Inserts `addressof(state)` into `state.sh_state->waiting_states`
+                    if `c` is `false`.
 
             3. If `c` is `true`, calls <code>state.<i>notify</i>()</code> and returns.
 

--- a/execution.bs
+++ b/execution.bs
@@ -5808,7 +5808,6 @@ namespace std::execution {
   struct let_stopped_t { <i>see below</i> };
   struct bulk_t { <i>see below</i> };
   struct split_t { <i>see below</i> };
-  struct ensure_started_t { <i>see below</i> };
   struct when_all_t { <i>see below</i> };
   struct when_all_with_variant_t { <i>see below</i> };
   struct into_variant_t { <i>see below</i> };
@@ -5827,7 +5826,6 @@ namespace std::execution {
   inline constexpr let_stopped_t let_stopped{};
   inline constexpr bulk_t bulk{};
   inline constexpr split_t split{};
-  inline constexpr ensure_started_t ensure_started{};
   inline constexpr when_all_t when_all{};
   inline constexpr when_all_with_variant_t when_all_with_variant{};
   inline constexpr into_variant_t into_variant{};
@@ -8372,37 +8370,34 @@ request but has no recommendataions at present.</span>
 
       - propagates all completion operations sent by `sndr`.
 
-#### `execution::split` and `execution::ensure_started` <b>[exec.split]</b> #### {#spec-execution.senders.adapt.split}
+#### `execution::split` <b>[exec.split]</b> #### {#spec-execution.senders.adapt.split}
 
 1. `split` adapts an arbitrary sender into a sender that can be connected
-    multiple times. `ensure_started` eagerly starts the execution of a sender,
-    returning a sender that is usable as input to additional sender algorithms.
+    multiple times.
 
-2. Let <i>`shared-env`</i> be the type of an environment such that,
+2. Let <i>`split-env`</i> be the type of an environment such that,
     given an instance `env`, the expression `get_stop_token(env)` is well-formed
     and has type `inplace_stop_token`.
 
-3. The names `split` and `ensure_started` denote pipeable sender adaptor closure objects.
-    Let the expression <i>`shared-cpo`</i> be one of `split` or
-    `ensure_started`. For a subexpression `sndr`, let `Sndr` be
-    `decltype((sndr))`. If <code>sender_in&lt;Sndr, <i>shared-env</i>></code> is
-    `false`, <code><i>shared-cpo</i>(sndr)</code> is ill-formed.
+3. The name `split` denotes a pipeable sender adaptor closure object.
+    For a subexpression `sndr`, let `Sndr` be `decltype((sndr))`. 
+	If <code>sender_in&lt;Sndr, <i>split-env</i>></code> is
+    `false`, <code>split(sndr)</code> is ill-formed.
 
-4. Otherwise, the expression <code><i>shared-cpo</i>(sndr)</code> is
+4. Otherwise, the expression <code>split(sndr)</code> is
     expression-equivalent to:
 
       <pre highlight="c++">
       transform_sender(
         <i>get-domain-early</i>(sndr),
-        <i>make-sender</i>(<i>shared-cpo</i>, {}, sndr))
+        <i>make-sender</i>(split, {}, sndr))
       </pre>
 
     except that `sndr` is evaluated only once.
 
     - <span class="wg21note">The default implementation of `transform_sender`
-        will have the effect of connecting the sender to a receiver and, in the
-        case of `ensure_started`, calling `start` on the resulting operation
-        state. It will return a sender with a different tag type.</span>
+        will have the effect of connecting the sender to a receiver.
+        It will return a sender with a different tag type.</span>
 
 5. Let <i>`local-state`</i> denote the following exposition-only class template:
 
@@ -8423,7 +8418,6 @@ request but has no recommendataions at present.</span>
         ~<i>local-state</i>();
 
         void <i>notify</i>() noexcept override;
-        void <i>detach</i>() noexcept override;
 
       private:
         optional&lt;<i>on-stop-callback</i>> on_stop; // exposition only
@@ -8451,7 +8445,6 @@ request but has no recommendataions at present.</span>
         1. *Effects:* Equivalent to:
 
             <pre highlight="c++">
-            <i>detach</i>();
             sh_state-><i>dec-ref</i>();
             </pre>
 
@@ -8470,39 +8463,28 @@ request but has no recommendataions at present.</span>
                   },
                   tupl);
               },
-              <i>QUAL</i>(sh_state->result));
+              as_const(sh_state->result));
             </pre>
 
-            where <i>`QUAL`</i> is `std::move` if
-            <code>same_as&lt;tag_of_t&lt;Sndr>,
-            <i>ensure-started-impl-tag</i>></code> is `true`, and `as_const`
-            otherwise.
-
-    4. <pre highlight="c++">
-        void <i>detach</i>() noexcept override;</pre>
-
-        1. *Effects:* Equivalent to <code>sh_state-><i>detach</i>()</code> if
-            <code>same_as&lt;tag_of_t&lt;Sndr>,
-            <i>ensure-started-impl-tag</i>></code> is `true`; otherwise,
-            nothing.
-
-6. Let <i>`shared-receiver`</i> denote the following exposition-only class
+6. Let <i>`split-receiver`</i> denote the following exposition-only class
     template:
 
     <pre highlight="c++">
     namespace std::execution {
       template&lt;class Sndr>
-      struct <i>shared-receiver</i> {
+      struct <i>split-receiver</i> {
         using receiver_concept = receiver_t;
 
         template&lt;class Tag, class... Args>
         void <i>complete</i>(Tag, Args&&... args) noexcept { <i>// exposition only</i>
+          using tuple_t = <i>decayed-tuple</i>&lt;Tag, Args...>;
           try {
-            using tuple_t = <i>decayed-tuple</i>&lt;Tag, Args...>;
             sh_state->result.template emplace&lt;tuple_t>(Tag(), std::forward&lt;Args>(args)...);
           } catch (...) {
-            using tuple_t = tuple&lt;set_error_t, exception_ptr>;
-            sh_state->result.template emplace&lt;tuple_t>(set_error, current_exception());
+			if constexpr (!is_nothrow_constructible_v&lt;tuple_t, Args...>) {
+              using err_tuple_t = tuple&lt;set_error_t, exception_ptr>;
+              sh_state->result.template emplace&lt;err_tuple_t>(set_error, current_exception());
+		    }
           }
           sh_state-><i>notify</i>();
         }
@@ -8552,7 +8534,6 @@ request but has no recommendataions at present.</span>
 
         void <i>start-op</i>() noexcept;  // exposition only
         void <i>notify</i>() noexcept;  // exposition only
-        void <i>detach</i>() noexcept;  // exposition only
         void <i>inc-ref</i>() noexcept; // exposition only
         void <i>dec-ref</i>() noexcept; // exposition only
 
@@ -8561,7 +8542,7 @@ request but has no recommendataions at present.</span>
         <i>state-list-type</i> waiting_states;    // exposition only
         atomic&lt;bool> completed{false};   // exposition only
         atomic&lt;size_t> ref_count{1};   // exposition only
-        connect_result_t&lt;Sndr, <i>shared-receiver</i>&lt;Sndr>> op_state;    // exposition only
+        connect_result_t&lt;Sndr, <i>split-receiver</i>&lt;Sndr>> op_state;    // exposition only
       };
     }
     </pre>
@@ -8584,7 +8565,7 @@ request but has no recommendataions at present.</span>
           explicit <i>shared-state</i>(Sndr&& sndr);</pre>
 
           1. *Effects:* Initializes `op_state` with the result of
-              <code>connect(std::forward&lt;Sndr>(sndr), <i>shared-receiver</i>{this})</code>.
+              <code>connect(std::forward&lt;Sndr>(sndr), <i>split-receiver</i>{this})</code>.
 
           2. *Postcondition:* `waiting_states` is empty, and `completed` is `false`.
 
@@ -8610,21 +8591,11 @@ request but has no recommendataions at present.</span>
               <code><i>dec-ref</i>()</code>.
 
       6. <pre highlight="c++">
-          void <i>detach</i>() noexcept;</pre>
-
-          1. *Effects:* If `completed` is `false` and `waiting_states` is empty,
-              calls `stop_src.request_stop()`. <span class="wg21note">This has
-              the effect of requesting early termination of any asynchronous
-              operation that was started as a result of a call to `ensure_started`,
-              but only if the resulting sender was never connected and started.
-              </span>
-
-      7. <pre highlight="c++">
           void <i>inc-ref</i>() noexcept;</pre>
 
           1. *Effects:* Increments `ref_count`.
 
-      8. <pre highlight="c++">
+      7. <pre highlight="c++">
           void <i>dec-ref</i>() noexcept;</pre>
 
           1. *Effects:* Decrements `ref_count`. If the new value of
@@ -8634,39 +8605,33 @@ request but has no recommendataions at present.</span>
               the `ref_count` to `0` then synchronizes with
               the call to <code><i>dec-ref</i>()</code> that decrements `ref_count` to `0`.
 
-8. For each type `split_t` and `ensure_started_t`, there is a different,
-    associated exposition-only implementation tag type, <i>`split-impl-tag`</i>
-    and <i>`ensure-started-impl-tag`</i>, respectively. Let
-    <i>`shared-impl-tag`</i> be the associated implementation tag type of
-    <i>`shared-cpo`</i>. Given an expression `sndr`, the expression
-    <code><i>shared-cpo</i>.transform_sender(sndr)</code> is equivalent to:
+8.  Given an expression `sndr`, the expression
+    <code>split.transform_sender(sndr)</code> is equivalent to:
 
       <pre highlight="c++">
       auto&& [tag, _, child] = sndr;
       auto* sh_state = new <i>shared-state</i>{std::forward_like&lt;decltype((sndr))>(child)};
-      return <i>make-sender</i>(<i>shared-impl-tag</i>(), <i>shared-wrapper</i>{sh_state, tag});
+      return <i>make-sender</i>(split, <i>shared-wrapper</i>{sh_state, tag});
       </pre>
 
     where <i>`shared-wrapper`</i> is an exposition-only class that manages the
     reference count of the <i>`shared-state`</i> object pointed to by `sh_state`.
     <i>`shared-wrapper`</i> models `movable` with move operations nulling out the
-    moved-from object. If `tag` is `split_t`, <i>`shared-wrapper`</i> models
+    moved-from object. `shared-wrapper`</i> models
     `copyable` with copy operations incrementing the reference count by calling
-    <code>sh_state-><i>inc-ref</i>()</code>. The constructor calls
-    <code>sh_state-><i>start-op</i>()</code> if `tag` is `ensure_started_t`. The
-    destructor has no effect if `sh_state` is null; otherwise, it calls
-    <code>sh_state-><i>detach</i>()</code> if `tag` is `ensure_started_t`;
-    and finally, it decrements the reference count by calling
+    <code>sh_state-><i>inc-ref</i>()</code>.  The
+    destructor has no effect if `sh_state` is null; otherwise, it
+    decrements the reference count by calling
     <code>sh_state-><i>dec-ref</i>()</code>.
 
 9. The exposition-only class template <i>`impls-for`</i>
-    ([exec.snd.general]) is specialized for <i>`shared-impl-tag`</i>
+    ([exec.snd.general]) is specialized for `split_t`
     as follows:
 
         <pre highlight="c++">
         namespace std::execution {
           template&lt;>
-          struct <i>impls-for</i>&lt;<i>shared-impl-tag</i>> : <i>default-impls</i> {
+          struct <i>impls-for</i>&lt;split_t> : <i>default-impls</i> {
             static constexpr auto <i>get-state</i> = <i>see below</i>;
             static constexpr auto <i>start</i> = <i>see below</i>;
           };
@@ -8674,7 +8639,7 @@ request but has no recommendataions at present.</span>
         </pre>
 
     1. The member
-        <code><i>impls-for</i>&lt;<i>shared-impl-tag</i>>::<i>get-state</i></code>
+        <code><i>impls-for</i>&lt;split_t>::<i>get-state</i></code>
         is initialized with a callable object equivalent to the following lambda
         expression:
 
@@ -8685,7 +8650,7 @@ request but has no recommendataions at present.</span>
           </pre>
 
     2. The member
-        <code><i>impls-for</i>&lt;<i>shared-impl-tag</i>>::<i>start</i></code>
+        <code><i>impls-for</i>&lt;split_t>::<i>start</i></code>
         is initialized with a callable object that has a call operator
         equivalent to the following:
 
@@ -8707,36 +8672,17 @@ request but has no recommendataions at present.</span>
                   <i>on-stop-request</i>{state.sh_state->stop_src})
                 </pre>
 
-            2. If <i>`shared-impl-tag`</i> is <i>`ensure-started-impl-tag`</i>,
-                and if `state.sh_state->stop_src.stop_requested()` is `true`,
-                calls `set_stopped(std::move(rcvr))` and returns.
+            2.  Then atomically does the following:
 
-            3.  Otherwise, atomically does the following:
+                  - Reads the value, `c`, of `state.sh_state->completed`.
 
-                  - Inserts `&state` into `state.sh_state->waiting_states`, and
+                  - If `c` is `false`, inserts `&state` into `state.sh_state->waiting_states`.
 
-                  - Reads the value of `state.sh_state->completed`.
+            3. If `c` is `true`, calls <code>state.<i>notify</i>()</code> and returns.
 
-            4. If the value read from `state.sh_state->completed` is `true`,
-                calls <code>state.<i>notify</i>()</code> and returns.
-
-            4. Otherwise, if <i>`shared-impl-tag`</i> is
-                <i>`split-impl-tag`</i>, and if `&state` is the first item added
+            4. Otherwise, if `&state` is the first item added
                 to `state.sh_state->waiting_states`, calls
                 <code>state.sh_state-><i>start-op</i>()</code>.
-
-10. <div class="wg21note">Under the following conditions, the results of the
-    child operation are discarded:
-
-    - When a sender returned from `ensure_started` is destroyed without being
-        connected to a receiver, or
-
-    - If the sender is connected to a receiver but the operation state
-        is destroyed without having been started, or
-
-    - If polling the receiver's stop token indicates that stop has been
-        requested when `start` is called, and the operation has not yet
-        completed.</div>
 
 #### `execution::when_all` <b>[exec.when.all]</b> #### {#spec-execution.senders.adaptor.when_all}
 

--- a/execution.bs
+++ b/execution.bs
@@ -1503,6 +1503,9 @@ The changes since R9 are as follows:
 
 <b>Fixes:</b>
 
+  * `ensure_started`, `start_detached`, `execute`, and `execute_may_block_caller`
+    are removed from the proposal. They are to be replaced with safer and more
+    structured APIs by [@P3149R3].
 
 <b>Enhancements:</b>
 
@@ -2303,7 +2306,7 @@ usages will only accept multi-shot senders.
 Algorithms that accept senders will typically either decay-copy an input sender
 and store it somewhere for later usage (for example as a data-member of the
 returned sender) or will immediately call `execution::connect` on the input
-sender, such as in `this_thread::sync_wait` or `execution::start_detached`.
+sender, such as in `this_thread::sync_wait`.
 
 Some multi-use sender algorithms may require that an input sender be
 copy-constructible but will only call `execution::connect` on an rvalue of each
@@ -2573,10 +2576,10 @@ accelerator can sometimes be considerable.
 However, in the process of working on this paper and implementations of the
 features proposed within, our set of requirements has shifted, as we understood
 the different implementation strategies that are available for the feature set
-of this paper better, and, after weighting the earlier concerns against the
+of this paper better, and, after weighing the earlier concerns against the
 points presented below, we have arrived at the conclusion that a purely lazy
 model is enough for most algorithms, and users who intend to launch work earlier
-may use an algorithm such as `ensure_started` to achieve that goal. We have also
+may write an algorithm to achieve that goal. We have also
 come to deeply appreciate the fact that a purely lazy model allows both the
 implementation and the compiler to have a much better understanding of what the
 complete graph of tasks looks like, allowing them to better optimize the code -
@@ -3239,8 +3242,7 @@ is related to the sender arguments it has received.
 Sender adaptors are <i>lazy</i>, that is, they are never allowed to submit any
 work for execution prior to the returned sender being [=started=] later on, and
 are also guaranteed to not start any input senders passed into them. Sender
-consumers such as [[#design-sender-consumer-start_detached]] and
-[[#design-sender-consumer-sync_wait]] start senders.
+consumers such as [[#design-sender-consumer-sync_wait]] start senders.
 
 For more implementer-centric description of starting senders, see
 [[#design-laziness]].
@@ -3483,49 +3485,10 @@ execution::sender auto final = execution::then(both, [](auto... args){
 // when final executes, it will print "the two args: 1, abc"
 </pre>
 
-### `execution::ensure_started` ### {#design-sender-adaptor-ensure_started}
-
-<pre highlight="c++">
-execution::sender auto ensure_started(
-    execution::sender auto sender
-);
-</pre>
-
-Once `ensure_started` returns, it is known that the provided sender has been
-[=connect|connected=] and `start` has been called on the resulting operation
-state (see [[#design-states]]); in other words, the work described by the
-provided sender has been submitted
-for execution on the appropriate execution resources. Returns a sender which
-completes when the provided sender completes and sends values equivalent to
-those of the provided sender.
-
-If the returned sender is destroyed before `execution::connect()` is called, or
-if `execution::connect()` is called but the returned operation-state is
-destroyed before `execution::start()` is called, then a stop-request is sent to
-the eagerly launched operation and the operation is detached and will run to
-completion in the background. Its result will be discarded when it eventually
-completes.
-
-Note that the application will need to make sure that resources are kept alive
-in the case that the operation detaches. e.g. by holding a `std::shared_ptr` to
-those resources or otherwise having some out-of-band way to signal completion of
-the operation so that resource release can be sequenced after the completion.
-
 ## User-facing sender consumers ## {#design-sender-consumers}
 
 A [=sender consumer=] is an algorithm that takes one or more senders, which it
 may `execution::connect`, as parameters, and does not return a sender.
-
-### `execution::start_detached` ### {#design-sender-consumer-start_detached}
-
-<pre highlight="c++">
-void start_detached(
-    execution::sender auto sender
-);
-</pre>
-
-Like `ensure_started`, but does not return a value; if the provided sender sends
-an error instead of a value, `std::terminate` is called.
 
 ### `this_thread::sync_wait` ### {#design-sender-consumer-sync_wait}
 
@@ -3537,12 +3500,12 @@ auto sync_wait(
 </pre>
 
 `this_thread::sync_wait` is a sender consumer that submits the work described by
-the provided sender for execution, similarly to `ensure_started`, except that it
-blocks <b>the current `std::thread` or thread of `main`</b> until the work is
+the provided sender for execution,
+blocking <b>the current `std::thread` or thread of `main`</b> until the work is
 completed, and returns an optional tuple of values that were sent by the
 provided sender on its completion of work. Where
 [[#design-sender-factory-schedule]] and [[#design-sender-factory-just]] are
-meant to <i>enter</i> the domain of senders, `sync_wait` is meant to <i>exit</i>
+meant to <i>enter</i> the domain of senders, `sync_wait` is one way to <i>exit</i>
 the domain of senders, retrieving the result of the task graph.
 
 If the provided sender sends an error instead of values, `sync_wait` throws that
@@ -3567,28 +3530,6 @@ would be provided. We also expect that runtimes with execution agents that use
 different synchronization mechanisms than `std::thread`'s will provide their own
 flavors of `sync_wait` as well (assuming their execution agents have the means
 to block in a non-deadlock manner).
-
-## `execution::execute` ## {#design-execute}
-
-In addition to the three categories of functions presented above, we also
-propose to include a convenience function for fire-and-forget eager one-way
-submission of an invocable to a scheduler, to fulfil the role of one-way
-executors from P0443.
-
-<pre highlight="c++">
-void execution::execute(
-    execution::schedule auto sched,
-    std::invocable<void> auto fn
-);
-</pre>
-
-Submits the provided function for execution on the provided scheduler, as-if by:
-
-<pre highlight="c++">
-auto snd = execution::schedule(sched);
-auto work = execution::then(snd, fn);
-execution::start_detached(work);
-</pre>
 
 # Design - implementer side # {#design-implementer}
 
@@ -3632,8 +3573,8 @@ algorithm: `start`, which serves as the submission point of the work represented
 by a given operation state.
 
 Operation states are not a part of the user-facing API of this proposal; they
-are necessary for implementing sender consumers like `execution::ensure_started`
-and `this_thread::sync_wait`, and the knowledge of them is necessary to
+are necessary for implementing sender consumers like `this_thread::sync_wait`,
+and the knowledge of them is necessary to
 implement senders, so the only users who will interact with operation states
 directly are authors of senders and authors of sender algorithms.
 
@@ -3765,9 +3706,7 @@ that accepts a sender as its first argument, should do the following:
 ## Sender adaptors are lazy ## {#design-laziness}
 
 Contrary to early revisions of this paper, we propose to make all sender
-adaptors perform strictly lazy submission, unless specified otherwise (the one
-notable exception in this paper is [[#design-sender-adaptor-ensure_started]],
-whose sole purpose is to start an input sender).
+adaptors perform strictly lazy submission, unless specified otherwise.
 
 <dfn export=true>Strictly lazy submission</dfn> means that there is a guarantee
 that no work is submitted to an execution resource before a receiver is
@@ -3794,10 +3733,7 @@ capable of removing the senders abstraction entirely, while still allowing for
 composition of functions across different parts of a program.
 
 The second way for this to occur is when a sender algorithm is specialized for a
-specific set of arguments. For instance, we expect that, for senders which are
-known to have been started already, [[#design-sender-adaptor-ensure_started]]
-will be an identity transformation, because the sender algorithm will be
-specialized for such senders. Similarly, an implementation could recognize two
+specific set of arguments. For instance, an implementation could recognize two
 subsequent [[#design-sender-adaptor-bulk]]s of compatible shapes, and merge them
 together into a single submission of a GPU kernel.
 

--- a/execution.bs
+++ b/execution.bs
@@ -8446,8 +8446,8 @@ request but has no recommendataions at present.</span>
           try {
             sh_state->result.template emplace&lt;tuple_t>(Tag(), std::forward&lt;Args>(args)...);
           } catch (...) {
-            using err_tuple_t = tuple&lt;set_error_t, exception_ptr>;
-            sh_state->result.template emplace&lt;err_tuple_t>(set_error, current_exception());
+            using tuple_t = tuple&lt;set_error_t, exception_ptr>;
+            sh_state->result.template emplace&lt;tuple_t>(set_error, current_exception());
           }
           sh_state-><i>notify</i>();
         }

--- a/execution.bs
+++ b/execution.bs
@@ -5284,7 +5284,6 @@ template&lt;class Initializer>
 <tr style="border-bottom-style: hidden;"><td><a href="#spec-execution.receivers">[exec.recv]</a></td><td>Receivers</td><td></td></tr>
 <tr style="border-bottom-style: hidden;"><td><a href="#spec-execution.opstate">[exec.opstate]</a></td><td>Operation states</td><td></td></tr>
 <tr style="border-bottom-style: hidden;"><td><a href="#spec-execution.senders">[exec.snd]</a></td><td>Senders</td><td></td></tr>
-<tr><td><a href="#spec-execution.execute">[exec.execute]</a></td><td>One-way execution</td><td></td></tr>
 </table>
 
 3. Table 2 shows the types of customization point objects
@@ -5300,7 +5299,7 @@ template&lt;class Initializer>
 <tr>
     <td>core</td>
     <td>provide core execution functionality, and connection between core components</td>
-    <td>e.g., `connect`, `start`, `execute`</td>
+    <td>e.g., `connect`, `start`</td>
 </tr>
 <tr>
     <td>completion functions</td>
@@ -5314,7 +5313,7 @@ template&lt;class Initializer>
         <ul>
             <li>sender factories (e.g., `schedule`, `just`, `read_env`)</li>
             <li>sender adaptors (e.g., `continues_on`, `then`, `let_value`)</li>
-            <li>sender consumers (e.g., `start_detached`, `sync_wait`)</li>
+            <li>sender consumers (e.g., `sync_wait`)</li>
         </ul>
     </td>
 </tr>
@@ -5325,7 +5324,7 @@ template&lt;class Initializer>
         <ul>
             <li>general queries (e.g., `get_allocator`, `get_stop_token`)</li>
             <li>environment queries (e.g., `get_scheduler`, `get_delegation_scheduler`)</li>
-            <li>scheduler queries (e.g., `get_forward_progress_guarantee`, `execute_may_block_caller`)</li>
+            <li>scheduler queries (e.g., `get_forward_progress_guarantee`)</li>
             <li>sender attribute queries (e.g., `get_completion_scheduler`)</li>
         </ul>
     </td>
@@ -5832,10 +5831,6 @@ namespace std::execution {
   inline constexpr stopped_as_optional_t stopped_as_optional{};
   inline constexpr stopped_as_error_t stopped_as_error{};
 
-  // [exec.consumers], sender consumers
-  struct start_detached_t { <i>see below</i> };
-  inline constexpr start_detached_t start_detached{};
-
   // [exec.utils], sender and receiver utilities
   // [exec.utils.cmplsigs]
   template&lt;class Fn>
@@ -5876,10 +5871,7 @@ namespace std::execution {
 }
 
 namespace std::this_thread {
-  // [exec.queries], queries
-  struct execute_may_block_caller_t { <i>see below</i> };
-  inline constexpr execute_may_block_caller_t execute_may_block_caller{};
-
+  // [exec.consumers], consumers
   struct sync_wait_t { <i>see below</i> };
   struct sync_wait_with_variant_t { <i>see below</i> };
 
@@ -5888,10 +5880,6 @@ namespace std::this_thread {
 }
 
 namespace std::execution {
-  // [exec.execute], one-way execution
-  struct execute_t { <i>see below</i> };
-  inline constexpr execute_t execute{};
-
   // [exec.as.awaitable]
   struct as_awaitable_t { <i>see below</i> };
   inline constexpr as_awaitable_t as_awaitable{};
@@ -6101,29 +6089,6 @@ namespace std::execution {
     forward progress guarantee. If it returns
     `forward_progress_guarantee::parallel`, all such execution agents shall
     provide at least the parallel forward progress guarantee.
-
-### `this_thread::execute_may_block_caller` <b>[exec.execute.may.block.caller]</b> ### {#spec-execution.execute_may_block_caller}
-
-1. `execute_may_block_caller` asks a scheduler `sch` whether any invocation of
-    the `execute` algorithm ([exec.execute]) with `sch` may block the current
-    thread of execution ([defns.block]).
-
-2. The name `execute_may_block_caller` denotes a query object. For
-    a subexpression `sch`, let `Sch` be `decltype((sch))`. If `Sch` does not
-    satisfy `scheduler`, `execute_may_block_caller(sch)` is ill-formed.
-    Otherwise, `execute_may_block_caller(sch)` is
-    expression-equivalent to:
-
-    1. <code><i>MANDATE-NOTHROW</i>(as_const(sch).query(execute_may_block_caller))</code>,
-        if that expression is well-formed.
-
-        * <i>Mandates:</i> The type of the expression above is `bool`.
-
-    2. Otherwise, `true`.
-
-3. If `execute_may_block_caller(sch)` returns `false` for some scheduler `sch`,
-    no invocation of the `execute` algorithm with `sch` shall block the calling
-    thread.
 
 ### `execution::get_completion_scheduler` <b>[exec.completion.scheduler]</b> ### {#spec-execution.get_completion_scheduler}
 
@@ -9101,63 +9066,6 @@ request but has no recommendataions at present.</span>
 
 ### Sender consumers <b>[exec.consumers]</b> ### {#spec-execution.senders.consumers}
 
-#### `execution::start_detached` <b>[exec.start.detached]</b> #### {#spec-execution.senders.consumers.start_detached}
-
-1. `start_detached` eagerly starts a sender without the caller needing to manage
-    the lifetimes of any objects.
-
-2. The name `start_detached` denotes a customization point object. For a
-    subexpression `sndr`, let `Sndr` be `decltype((sndr))`. If
-    `sender_in<Sndr, empty_env>` is `false`, `start_detached` is ill-formed.
-    Otherwise, the expression `start_detached(sndr)` is expression-equivalent to
-    the following except that `sndr` is evaluated only once:
-
-    <pre highlight="c++">
-    apply_sender(<i>get-domain-early</i>(sndr), start_detached, sndr)
-    </pre>
-
-    * <i>Mandates:</i> <code>same_as&lt;decltype(<em>e</em>), void></code> is
-        `true` where <code><em>e</em></code> is the expression above.
-
-    If the expression above does not eagerly start the sender `sndr` after
-    connecting it with a receiver that ignores value and stopped completion
-    operations and calls `terminate()` on error completions, the behavior of
-    calling `start_detached(sndr)` is undefined.
-
-3. Let `sndr` be a subexpression such that `Sndr` is `decltype((sndr))`, and let
-    <i>`detached-receiver`</i> and
-    <i>`detached-operation`</i> be the following exposition-only
-    class templates:
-
-    <pre highlight="c++">
-    namespace std::execution {
-      template&lt;class Sndr>
-      struct <i>detached-receiver</i> {
-        using receiver_concept = receiver_t;
-        <i>detached-operation</i>&lt;Sndr>* <i>op</i>; <i>// exposition only</i>
-
-        void set_value() && noexcept { delete op; }
-        void set_error() && noexcept { terminate(); }
-        void set_stopped() && noexcept { delete op; }
-        empty_env get_env() const noexcept { return {}; }
-      };
-
-      template&lt;class Sndr>
-      struct <i>detached-operation</i> {
-        connect_result_t&lt;Sndr, <i>detached-receiver</i>&lt;Sndr>> <i>op</i>; <i>// exposition only</i>
-
-        explicit <i>detached-operation</i>(Sndr&& sndr)
-          : <i>op</i>(connect(std::forward&lt;Sndr>(sndr), <i>detached-receiver</i>&lt;Sndr>{this}))
-        {}
-      };
-    }
-    </pre>
-
-4. If <code>sender_to&lt;Sndr, <i>detached-receiver</i>&lt;Sndr>></code> is `false`, the
-    expression `start_detached.apply_sender(sndr)` is ill-formed; otherwise, it is
-    expression-equivalent to <code>start((new
-    <i>detached-operation</i>&lt;Sndr>(sndr))-><i>op</i>)</code>.
-
 #### `this_thread::sync_wait` <b>[exec.sync.wait]</b> #### {#spec-execution.senders.consumers.sync_wait}
 
 1. `this_thread::sync_wait` and `this_thread::sync_wait_with_variant` are used
@@ -9370,29 +9278,6 @@ request but has no recommendataions at present.</span>
         2. For an error completion, an exception is thrown.
 
         3. For a stopped completion, a disengaged `optional` object is returned.
-
-## `execution::execute` <b>[exec.execute]</b> ## {#spec-execution.execute}
-
-1. `execute` executes a specified callable object on a specified scheduler.
-
-2. The name `execute` denotes a customization point object. For some
-    subexpressions `sch` and `f`, let `Sch` be `decltype((sch))` and `F` be the
-    decayed type of `f`. If `Sch` does not satisfy `scheduler` or `F` does not
-    satisfy `invocable`, `execute(sch, f)` is ill-formed. Otherwise,
-    `execute(sch, f)` is expression-equivalent to:
-
-    <pre highlight="c++">
-    apply_sender(
-      <i>query-or-default</i>(get_domain, sch, default_domain()),
-      execute, schedule(sch), f)
-    </pre>
-
-    * <i>Mandates:</i> The type of the expression above is `void`.
-
-3. For some subexpressions `sndr` and `f` where `F` is the decayed type of `f`,
-    if `F` does not satisfy `invocable`, the expression
-    `execute.apply_sender(sndr, f)` is ill-formed; otherwise it is
-    expression-equivalent to `start_detached(then(sndr, f))`.
 
 ## Sender/receiver utilities <b>[exec.utils]</b> ## {#spec-execution.snd_rec_utils}
 

--- a/execution.bs
+++ b/execution.bs
@@ -8372,7 +8372,6 @@ request but has no recommendataions at present.</span>
       struct <i>local-state-base</i> {          // exposition only
         virtual ~<i>local-state-base</i>() = default;
         virtual void <i>notify</i>() noexcept = 0; // exposition only
-        virtual void <i>detach</i>() noexcept = 0; // exposition only
       };
 
       template&lt;class Sndr, class Rcvr>
@@ -8422,14 +8421,14 @@ request but has no recommendataions at present.</span>
             <pre highlight="c++">
             on_stop.reset();
             visit(
-              [this]&lt;class Tuple>(Tuple&& tupl) noexcept -> void {
+              [this](const auto& tupl) noexcept -> void {
                 apply(
-                  [this](auto tag, auto&... args) noexcept -> void {
-                    tag(std::move(*rcvr), std::forward_like&lt;Tuple>(args)...);
+                  [this](auto tag, const auto&... args) noexcept -> void {
+                    tag(std::move(*rcvr), args...);
                   },
                   tupl);
               },
-              as_const(sh_state->result));
+              sh_state->result);
             </pre>
 
 6. Let <i>`split-receiver`</i> denote the following exposition-only class
@@ -8447,10 +8446,8 @@ request but has no recommendataions at present.</span>
           try {
             sh_state->result.template emplace&lt;tuple_t>(Tag(), std::forward&lt;Args>(args)...);
           } catch (...) {
-			if constexpr (!is_nothrow_constructible_v&lt;tuple_t, Args...>) {
-              using err_tuple_t = tuple&lt;set_error_t, exception_ptr>;
-              sh_state->result.template emplace&lt;err_tuple_t>(set_error, current_exception());
-		    }
+            using err_tuple_t = tuple&lt;set_error_t, exception_ptr>;
+            sh_state->result.template emplace&lt;err_tuple_t>(set_error, current_exception());
           }
           sh_state-><i>notify</i>();
         }
@@ -8571,33 +8568,34 @@ request but has no recommendataions at present.</span>
               the `ref_count` to `0` then synchronizes with
               the call to <code><i>dec-ref</i>()</code> that decrements `ref_count` to `0`.
 
-8.  Given an expression `sndr`, the expression
+8. Let <i>`split-impl-tag`</i> be an empty exposition-only class type.
+    Given an expression `sndr`, the expression
     <code>split.transform_sender(sndr)</code> is equivalent to:
 
       <pre highlight="c++">
       auto&& [tag, _, child] = sndr;
       auto* sh_state = new <i>shared-state</i>{std::forward_like&lt;decltype((sndr))>(child)};
-      return <i>make-sender</i>(split, <i>shared-wrapper</i>{sh_state, tag});
+      return <i>make-sender</i>(<i>split-impl-tag</i>(), <i>shared-wrapper</i>{sh_state, tag});
       </pre>
 
     where <i>`shared-wrapper`</i> is an exposition-only class that manages the
     reference count of the <i>`shared-state`</i> object pointed to by `sh_state`.
-    <i>`shared-wrapper`</i> models `movable` with move operations nulling out the
-    moved-from object. `shared-wrapper`</i> models
-    `copyable` with copy operations incrementing the reference count by calling
-    <code>sh_state-><i>inc-ref</i>()</code>.  The
+    <i>`shared-wrapper`</i> models `copyable` with move operations nulling out the
+    moved-from object, copy operations incrementing the reference count by calling
+    <code>sh_state-><i>inc-ref</i>()</code>, and assignment operations performing
+    a copy-and-swap operation. The
     destructor has no effect if `sh_state` is null; otherwise, it
     decrements the reference count by calling
     <code>sh_state-><i>dec-ref</i>()</code>.
 
 9. The exposition-only class template <i>`impls-for`</i>
-    ([exec.snd.general]) is specialized for `split_t`
+    ([exec.snd.general]) is specialized for _`split-impl-tag`_
     as follows:
 
         <pre highlight="c++">
         namespace std::execution {
           template&lt;>
-          struct <i>impls-for</i>&lt;split_t> : <i>default-impls</i> {
+          struct <i>impls-for</i>&lt;<i>split-impl-tag</i>> : <i>default-impls</i> {
             static constexpr auto <i>get-state</i> = <i>see below</i>;
             static constexpr auto <i>start</i> = <i>see below</i>;
           };
@@ -8605,7 +8603,7 @@ request but has no recommendataions at present.</span>
         </pre>
 
     1. The member
-        <code><i>impls-for</i>&lt;split_t>::<i>get-state</i></code>
+        <code><i>impls-for</i>&lt;<i>split-impl-tag</i>>::<i>get-state</i></code>
         is initialized with a callable object equivalent to the following lambda
         expression:
 
@@ -8616,7 +8614,7 @@ request but has no recommendataions at present.</span>
           </pre>
 
     2. The member
-        <code><i>impls-for</i>&lt;split_t>::<i>start</i></code>
+        <code><i>impls-for</i>&lt;<i>split-impl-tag</i>>::<i>start</i></code>
         is initialized with a callable object that has a function call operator
         equivalent to the following:
 
@@ -8640,9 +8638,9 @@ request but has no recommendataions at present.</span>
 
             2.  Then atomically does the following:
 
-                  - Reads the value, `c`, of `state.sh_state->completed`.
+                  - Inserts `&state` into `state.sh_state->waiting_states`, and
 
-                  - If `c` is `false`, inserts `addressof(state)` into `state.sh_state->waiting_states`.
+                  - Reads the value `c` of `state.sh_state->completed`.
 
             3. If `c` is `true`, calls <code>state.<i>notify</i>()</code> and returns.
 


### PR DESCRIPTION
Removes the following facilities as specified in P3187R1:
* `ensure_started()`
* `execute()`
* `start_detached()`

Also removes the following facility as it does not make sense any more:
* `execute_may_block_caller`

Note: `ensure_started()` algorithm had wording shared with `split()`
The common wording has now been simplified to now only describe `split()`.