### PR TITLE
Fix typo in example: as_writeable_bytes -> as_writable_bytes

### DIFF
--- a/execution.bs
+++ b/execution.bs
@@ -389,7 +389,7 @@ struct dynamic_buffer {                                                       //
 sender_of<dynamic_buffer> auto async_read_array(auto handle) {                // 2
   return just(dynamic_buffer{})                                               // 4
        | let_value([handle] (dynamic_buffer& buf) {                           // 5
-           return just(std::as_writeable_bytes(std::span(&buf.size, 1)))      // 6
+           return just(std::as_writable_bytes(std::span(&buf.size, 1)))       // 6
                 | async_read(handle)                                          // 7
                 | then(                                                       // 8
                     [&buf] (std::size_t bytes_read) {                         // 9


### PR DESCRIPTION
Fixes #217